### PR TITLE
wrong systemctl parameter

### DIFF
--- a/07-hosting.Rmd
+++ b/07-hosting.Rmd
@@ -410,7 +410,7 @@ WantedBy=multi-user.target
 3. Activate the service (for auto-start on power/reboot) and start it:
 
 ```
-sudo systemctl activate plumber-api   # automatically start the service when the server boots
+sudo systemctl enable plumber-api   # automatically start the service when the server boots
 sudo systemctl start plumber-api      # start the service right now
 ```
 


### PR DESCRIPTION
The correct systemctl parameter is "enable" and not "activate".