### PR TITLE
Change systemctl automatic start command

### DIFF
--- a/07-hosting.Rmd
+++ b/07-hosting.Rmd
@@ -410,8 +410,8 @@ WantedBy=multi-user.target
 3. Activate the service (for auto-start on power/reboot) and start it:
 
 ```
-sudo systemctl enable plumber-api     # automatically start the service when the server boots
-sudo systemctl start plumber-api      # start the service right now
+sudo systemctl enable plumber-api  # automatically start the service when the server boots
+sudo systemctl start plumber-api   # start the service right now
 ```
 
 To check if your API is running, type `systemctl | grep running` in the terminal and should display `plumber-api.service \ loaded active running Plumber API`.

--- a/07-hosting.Rmd
+++ b/07-hosting.Rmd
@@ -410,7 +410,7 @@ WantedBy=multi-user.target
 3. Activate the service (for auto-start on power/reboot) and start it:
 
 ```
-sudo systemctl activate plumber-api   # automatically start the service when the server boots
+sudo systemctl enable plumber-api     # automatically start the service when the server boots
 sudo systemctl start plumber-api      # start the service right now
 ```
 


### PR DESCRIPTION
Update the instructions for automatically starting a systemd service to use `enable` not `activate`.

(This seems to be the correct command though I'm not a Linux expert so don't know if it's the same on every distro)