### PR TITLE
Make the pm2 application accessible externally

### DIFF
--- a/07-hosting.Rmd
+++ b/07-hosting.Rmd
@@ -342,7 +342,8 @@ Unfortunately, pm2 doesn't understand R scripts natively; however, it is possibl
 library(plumber)
 pr <- plumb('myfile.R')
 pr$run(port=4000, host="0.0.0.0") 
-#Setting the host option on a VM instance ensures the application can be accessed externally. This may be only true for Linux users.
+# Setting the host option on a VM instance ensures the application can be accessed externally.
+# (This may be only true for Linux users.)
 ```
 
 Save this R script on your server as something like `run-myfile.R`. You should also make it executable by changing the permissions on the file using a command like `chmod 755 run-myfile.R`. You should now execute that file to make sure that it runs the service like you expect. You should be able to make requests to your server on the appropriate port and have the plumber service respond. You can kill the process using `Ctrl-c` when you're convinced that it's working. Make sure the shell script is in a permanent location so that it won't be erased or modified accidentally. You can consider creating a designated directory for all your plumber services in some directory like `/usr/local/plumber`, then put all services and their associated Rscript-runners in their own subdirectory like `/usr/local/plumber/myfile/`.
@@ -365,7 +366,7 @@ At this point, you have a persistent pm2 service created for your Plumber applic
 
 You can repeat this process with all the plumber applications you want to deploy, as long as you give each a unique port to run on. Remember that you can't have more than one service running on a single port. And be sure to `pm2 save` every time you add services that you want to survive a restart.
 
-Run `netstat -tulpn` to see how the application is being ran. If you see the application on host 127.0.0.0/1, the application cannot be accessed externally. You should change the host parameter to 0.0.0.0 (quoted) in the `run` method of plumber
+Run `netstat -tulpn` to see how the application is being ran. If you see the application on host `127.0.0.0` or `127.0.0.1`, the application cannot be accessed externally. You should change the host parameter to `0.0.0.0`, for example: `pr$run(host = "0.0.0.0").
 
 ### Logs and Management
 

--- a/07-hosting.Rmd
+++ b/07-hosting.Rmd
@@ -341,7 +341,8 @@ Unfortunately, pm2 doesn't understand R scripts natively; however, it is possibl
 
 library(plumber)
 pr <- plumb('myfile.R')
-pr$run(port=4000)
+pr$run(port=4000, host="0.0.0.0") 
+#Setting the host option on a VM instance ensures the application can be accessed externally. This may be only true for Linux users.
 ```
 
 Save this R script on your server as something like `run-myfile.R`. You should also make it executable by changing the permissions on the file using a command like `chmod 755 run-myfile.R`. You should now execute that file to make sure that it runs the service like you expect. You should be able to make requests to your server on the appropriate port and have the plumber service respond. You can kill the process using `Ctrl-c` when you're convinced that it's working. Make sure the shell script is in a permanent location so that it won't be erased or modified accidentally. You can consider creating a designated directory for all your plumber services in some directory like `/usr/local/plumber`, then put all services and their associated Rscript-runners in their own subdirectory like `/usr/local/plumber/myfile/`.
@@ -363,6 +364,8 @@ Once you're happy with the pm2 services you have defined, you can use `pm2 save`
 At this point, you have a persistent pm2 service created for your Plumber application. This means that you can reboot your server, or find and kill the underlying R process that your plumber application is using and pm2 will automatically bring a new process in to replace it. This should help guarantee that you always have a Plumber process running on the port number you specified in the shell script. It is a good idea to reboot the server to ensure that everything comes back the way you expected.
 
 You can repeat this process with all the plumber applications you want to deploy, as long as you give each a unique port to run on. Remember that you can't have more than one service running on a single port. And be sure to `pm2 save` every time you add services that you want to survive a restart.
+
+Run `netstat -tulpn` to see how the application is being ran. If you see the application on host 127.0.0.0/1, the application cannot be accessed externally. You should change the host parameter to 0.0.0.0 (quoted) in the `run` method of plumber
 
 ### Logs and Management
 


### PR DESCRIPTION
While the doc on pm2 is very good, not adding the host parameter to the  `run` method only makes the application accessible internally. If you are following this through on a VM, it is important that the host parameter is added to make the application accessible in a browser.